### PR TITLE
add intBoard clone for constructor (when cloning board state)

### DIFF
--- a/src/Saboteur/SaboteurBoardState.java
+++ b/src/Saboteur/SaboteurBoardState.java
@@ -100,6 +100,8 @@ public class SaboteurBoardState extends BoardState {
         }
         this.rand = pbs.rand;
 
+        this.intBoard = pbs.getIntBoard().clone();
+
         //we are not looking for shallow copy (where element are not copied) but deep copy, so that the user can't destroy the board that is sent to him...
         this.player1Cards = new ArrayList<SaboteurCard>();
         for(int i=0;i<pbs.player1Cards.size();i++){


### PR DESCRIPTION
Hello,

We found out that there may be a missing line in the SaboteurBoardState constructor (the one used when cloning a board state) as there is no assignment to the intBoard, which results in null pointer exceptions if we ever want to process moves on a cloned board. I was wondering if this missing attribute was intended. If not, is it possible to push a fix to it? 
This is the change we made to be able to successfully work with cloned board states, but feel free to modify the line of code.

Thanks!